### PR TITLE
Adding funding links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: MikeRogers0
+custom: https://typoci.com/
+custom: https://mikerogers.io/


### PR DESCRIPTION
Typo CI is currently free, so adding Sponsorship links to this repo.