### PR TITLE
Removing turbolinks

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -8,13 +8,13 @@
     <title><%= current_page.data.title %> | Typo CI</title>
     <meta name="description" content="<%= current_page.data.description %>">
     
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%#= javascript_link_tag 'application', 'data-turbolinks-track': 'reload' %>
-    <link href="https://fonts.googleapis.com/css?family=Alegreya:400,400i,700,700i|Montserrat:400,700&display=swap" rel="stylesheet" media="all" data-turbolinks-track="reload">
+    <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%#= javascript_link_tag 'application' %>
+    <link href="https://fonts.googleapis.com/css?family=Alegreya:400,400i,700,700i|Montserrat:400,700&display=swap" rel="stylesheet" media="all">
 
-    <link rel="apple-touch-icon" href="<%= image_path("apple-icon.png") %>" data-turbolinks-track="reload" />
-    <link rel="shortcut icon" href="<%= image_path("favicon.png") %>" data-turbolinks-track="reload" />
-    <link rel="icon" type="image/ico" href="<%= image_path("favicon.ico") %>" data-turbolinks-track="reload" />
+    <link rel="apple-touch-icon" href="<%= image_path("apple-icon.png") %>" />
+    <link rel="shortcut icon" href="<%= image_path("favicon.png") %>" />
+    <link rel="icon" type="image/ico" href="<%= image_path("favicon.ico") %>" />
     <link rel="manifest" href="/manifest.json">
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="<%= image_path("ms-icon.png") %>">

--- a/source/shared/_footer.html.erb
+++ b/source/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<div class="footer mt-4" id="footer" data-turbolinks-permanent>
+<div class="footer mt-4" id="footer">
   <footer class="container footer__grid">
     <div class="footer__links">
       <div class="h4">Product</div>

--- a/source/shared/_header.html.erb
+++ b/source/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="container header" id="header" data-turbolinks-permanent>
+<header class="container header" id="header">
     <div class="header__logo">
       <a href="/" class="h4 logo__link">
         <%= image_tag 'typo-ci-logo.svg', width: '48', class: 'logo__image', alt: "Typo CI Logo - It's a sword surrounded by brackets" %>


### PR DESCRIPTION
I used Turbolinks in my Rails app. It's awesome, but as this site is now JS free I'm feeling just removing it completely.

This removes the turbolinks artefacts.