### PR TITLE
fix: JSON-D product image link was ERB

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,7 +9,7 @@ layout: default
     "@context": "http://schema.org/",
     "@type": "Product",
     "name": "Typo CI",
-    "image": "<%= image_path('typo-ci-logo.png') %>",
+    "image": "https://typoci.com/images/typo-ci-logo.png",
     "description": "Check your code for common spelling mistakes and correct them before you merge them",
     "sku": "typo-ci-early-bird",
     "brand": {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/325384/89195728-152dde80-d5a1-11ea-8bda-94f3a654a4e5.png)

Google gave me a heads up. Tbh these JSON-D's are such a waste of time, I'm not convinced they make a difference to ranking.