### PR TITLE
Replace links from GitHub App to be GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@
   Typo CI - Marketing Site
 </h1>
 
-<p align="center">
-Checks for spelling errors within commits by listening to webhooks from GitHub.
-</p>
-
 ## Setup & Running Locally
 
 Clone down the repo, install [Docker](https://hub.docker.com/editions/community/docker-ce-desktop-mac/) & run:

--- a/src/_components/footer.liquid
+++ b/src/_components/footer.liquid
@@ -5,7 +5,7 @@
 
       <ul class="list-unstyled">
         <li>
-          <a href="https://github.com/marketplace/typo-ci" target="_blank", rel="noopener">Add via GitHub Marketplace</a>
+          <a href="https://github.com/marketplace/actions/typo-ci-spellcheck-action" target="_blank", rel="noopener">View in GitHub Marketplace</a>
         </li>
         <li>
           <a href="/documentation">Documentation</a>

--- a/src/_components/footer.liquid
+++ b/src/_components/footer.liquid
@@ -5,7 +5,7 @@
 
       <ul class="list-unstyled">
         <li>
-          <a href="https://github.com/marketplace/actions/typo-ci-spellcheck-action" target="_blank", rel="noopener">View in GitHub Marketplace</a>
+          <a href="https://github.com/marketplace/actions/typo-ci-spellcheck-action" target="_blank", rel="noopener">Add via GitHub Marketplace</a>
         </li>
         <li>
           <a href="/documentation">Documentation</a>

--- a/src/_components/navbar.liquid
+++ b/src/_components/navbar.liquid
@@ -6,7 +6,7 @@
       </a>
     </div>
     <div class="header__action">
-      <a href="https://github.com/marketplace/typo-ci" class="btn btn-primary">
+      <a href="https://github.com/marketplace/actions/typo-ci-spellcheck-action" class="btn btn-primary">
         <div>Get Started</div>
       </a>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -37,7 +37,7 @@ layout: default
       "@type": "Offer",
       "priceCurrency": "USD",
       "price": "0.00",
-      "url": "https://github.com/marketplace/typo-ci",
+      "url": "https://github.com/marketplace/actions/typo-ci-spellcheck-action",
       "priceValidUntil": "2020-01-01",
       "availability": "http://schema.org/InStock",
       "seller": {
@@ -64,7 +64,7 @@ layout: default
   </ul>
 
   <div class="jumbotron__actions">
-    <a href="https://github.com/marketplace/typo-ci" class="btn btn-primary">Get Started</a>
+    <a href="https://github.com/marketplace/actions/typo-ci-spellcheck-action" class="btn btn-primary">Get Started</a>
     <a href="/documentation" class="btn btn-outline-primary mx-2">Read Documentation</a>
   </div>
 </section>
@@ -92,6 +92,6 @@ layout: default
   </div>
 
   <div class="jumbotron__actions">
-    <a href="https://github.com/marketplace/typo-ci" class="btn btn-primary">Get Started</a>
+    <a href="https://github.com/marketplace/actions/typo-ci-spellcheck-action" class="btn btn-primary">Get Started</a>
   </div>
 </section>


### PR DESCRIPTION
I don't want to promote the marketplace GitHub App anymore, I get the feeling GitHub isn't planning to keep the feature going much longer.

Instead I'm going to focus my efforts on the GitHub Action.