### PR TITLE
Removing Anchor links to marketplace

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -64,7 +64,7 @@ layout: default
   </ul>
 
   <div class="jumbotron__actions">
-    <a href="https://github.com/marketplace/typo-ci#pricing-and-setup" class="btn btn-primary">Get Started</a>
+    <a href="https://github.com/marketplace/typo-ci" class="btn btn-primary">Get Started</a>
     <a href="/documentation" class="btn btn-outline-primary mx-2">Read Documentation</a>
   </div>
 </section>
@@ -92,6 +92,6 @@ layout: default
   </div>
 
   <div class="jumbotron__actions">
-    <a href="https://github.com/marketplace/typo-ci#pricing-and-setup" class="btn btn-primary">Get Started</a>
+    <a href="https://github.com/marketplace/typo-ci" class="btn btn-primary">Get Started</a>
   </div>
 </section>


### PR DESCRIPTION
I'm not convinced they make for a good UX as instead of landing on the "Ok here is what you're about to install", users could end up thinking they're about to pay money.

So ditching them & observing the difference in sales.